### PR TITLE
Add metadata and env to spec-based results

### DIFF
--- a/jupyter_kernel_mgmt/discovery.py
+++ b/jupyter_kernel_mgmt/discovery.py
@@ -65,6 +65,8 @@ class KernelSpecProvider(KernelProviderBase):
                 'display_name': spec.display_name,
                 'argv': spec.argv,
                 'resource_dir': spec.resource_dir,
+                'metadata': spec.metadata,
+                'env': spec.env,
             }
 
     def launch(self, name, cwd=None):


### PR DESCRIPTION
Looks like the metadata stanza was inadvertently dropped from kernel
spec provider types.  This change restores the metadata dictionary
into the result.