### PR TITLE
Let KernelManager hold kernel_id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ __pycache__
 .cache
 .pytest_cache
 absolute.json
+.idea/

--- a/jupyter_kernel_mgmt/managerabc.py
+++ b/jupyter_kernel_mgmt/managerabc.py
@@ -3,6 +3,9 @@ import asyncio
 import six
 
 class KernelManagerABC(six.with_metaclass(ABCMeta, object)):
+
+    kernel_id = None  # Subclass should set kernel_id during initialization
+
     @abstractmethod
     def is_alive(self):
         """Check whether the kernel is currently alive (e.g. the process exists)

--- a/jupyter_kernel_mgmt/subproc/manager.py
+++ b/jupyter_kernel_mgmt/subproc/manager.py
@@ -12,6 +12,7 @@ import six
 import subprocess
 import sys
 import time
+import uuid
 
 log = logging.getLogger(__name__)
 
@@ -39,6 +40,7 @@ class KernelManager(KernelManagerABC):
         self.files_to_cleanup = files_to_cleanup or []
         self.win_interrupt_evt = win_interrupt_evt
         self.log = get_app_logger()
+        self.kernel_id = str(uuid.uuid4())
 
     def wait(self, timeout):
         """"""


### PR DESCRIPTION
Kernel providers will want to use the same kernel_id used by the
MappingKernelManager as a means of managing a kernel's lifecycle.
This PR adds a `kernel_id` member to the KernelManager abstract
base class and initializes its value in the KernelManager constructor.
This allows kernel providers to determine the best location for where
to set `kernel_id` so that it can be used to manage the kerne's
lifecycle.

The MappingKernelManager start logic will then derive the kernel_id
from the provider's KernelManager instance.

Fixes #10