### PR TITLE
Async support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python:
     - 3.6
     - 3.5
-    - 3.4
 install:
   - pip install --upgrade setuptools pip
   - pip install --upgrade -e .[test] pytest-cov codecov

--- a/jupyter_kernel_mgmt/tests/test_async_manager.py
+++ b/jupyter_kernel_mgmt/tests/test_async_manager.py
@@ -21,10 +21,9 @@ class TestKernelManager(TestCase):
     def tearDown(self):
         self.env_patch.stop()
 
-    @asyncio.coroutine
-    def t_get_connect_info(self):
+    async def t_get_connect_info(self):
         launcher = AsyncSubprocessKernelLauncher(make_ipkernel_cmd(), os.getcwd())
-        info, km = yield from launcher.launch()
+        info, km = await launcher.launch()
         try:
             self.assertEqual(set(info.keys()), {
                 'ip', 'transport',
@@ -32,17 +31,16 @@ class TestKernelManager(TestCase):
                 'key', 'signature_scheme',
             })
         finally:
-            yield from km.kill()
-            yield from km.cleanup()
+            await km.kill()
+            await km.cleanup()
 
     def test_get_connect_info(self):
         asyncio.get_event_loop().run_until_complete(self.t_get_connect_info())
 
-    @asyncio.coroutine
-    def t_start_new_kernel(self):
-        km, kc = yield from start_new_kernel(make_ipkernel_cmd(), startup_timeout=TIMEOUT)
+    async def t_start_new_kernel(self):
+        km, kc = await start_new_kernel(make_ipkernel_cmd(), startup_timeout=TIMEOUT)
         try:
-            self.assertTrue((yield from km.is_alive()))
+            self.assertTrue((await km.is_alive()))
             self.assertTrue(kc.is_alive())
         finally:
             kc.shutdown_or_terminate()

--- a/jupyter_kernel_mgmt/tests/test_restarter.py
+++ b/jupyter_kernel_mgmt/tests/test_restarter.py
@@ -1,16 +1,22 @@
+import asyncio
 from .test_discovery import DummyKernelManager, DummyKernelProvider
 
 from jupyter_kernel_mgmt import discovery
 from jupyter_kernel_mgmt.restarter import KernelRestarterBase
 
-def test_reinstantiate():
+
+async def t_reinstantiate():
     # If the kernel fails, a new manager should be instantiated
     kf = discovery.KernelFinder(providers=[DummyKernelProvider()])
-    _, manager = kf.launch('dummy/sample')
-    manager.kill()
+    _, manager = await kf.launch('dummy/sample')
+    await manager.kill()
 
     restarter = KernelRestarterBase(manager, 'dummy/sample', kernel_finder=kf)
     assert restarter.kernel_manager is manager
-    restarter.poll()
+    await restarter.poll()
     assert restarter.kernel_manager is not manager
-    assert restarter.kernel_manager.is_alive()
+    assert await restarter.kernel_manager.is_alive()
+
+
+def test_reinstantiate():
+    asyncio.get_event_loop().run_until_complete(t_reinstantiate())

--- a/jupyter_kernel_mgmt/tests/utils.py
+++ b/jupyter_kernel_mgmt/tests/utils.py
@@ -1,6 +1,7 @@
 """Testing utils for jupyter_client tests
 
 """
+import asyncio
 import os
 pjoin = os.path.join
 import sys
@@ -61,3 +62,7 @@ def execute(code='', kc=None, **kwargs):
         assert execute_input['content']['code'] == code
 
     return msg_id, reply['content']
+
+
+def run_sync(coro_method):
+    return asyncio.get_event_loop().run_until_complete(coro_method)

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ from setuptools import setup
 from setuptools.command.bdist_egg import bdist_egg
 
 v = sys.version_info
-if v[:2] < (3, 4):
-    error = "ERROR: %s requires Python version 3.4 or above." % name
+if v[:2] < (3, 5):
+    error = "ERROR: %s requires Python version 3.5 or above." % name
     print(error, file=sys.stderr)
     sys.exit(1)
 
@@ -73,7 +73,7 @@ setup_args = dict(
     extras_require   = {
         'test': ['ipykernel', 'ipython', 'mock', 'pytest'],
     },
-    python_requires = ">=3.4",
+    python_requires = ">=3.5",
     cmdclass         = {
         'bdist_egg': bdist_egg if 'bdist_egg' in sys.argv else bdist_egg_disabled,
     },


### PR DESCRIPTION
Got start and restarts working.  I've switched to a single launch method that is defined as aync.  This is because we can't have both due to the way restarts work (calling the (previously synchronous) launch method and we shouldn't require providers to implement both forms - especially when async support is required to be implemented deep in the provider (i.e., it may not be practical to implement both forms).  Since async support is clearly warranted and in line with future directions, we should adopt at as the single mechanism.

By switching to a single method, providers that ONLY support synchronous operations can still implement their provider that way, but will need to invoke the KernelFinder (or provider's) launch method using something like the following (from tests/utils.py):

```python
def run_sync(coro_method):
    return asyncio.get_event_loop().run_until_complete(coro_method)
```
Removed support for Python 3.4 so we could just focus on 3.5+ with async/await.

The experimental notebook branch has been modified to make calls with knowledge that async support is implemented.