### PR TITLE
Replace Client2 with Client

### DIFF
--- a/jupyter_kernel_mgmt/client.py
+++ b/jupyter_kernel_mgmt/client.py
@@ -565,7 +565,7 @@ class BlockingKernelClient:
 
 
 class ClientInThread(Thread):
-    """Run an IOLoopKernelClient2 in a separate thread.
+    """Run an IOLoopKernelClient in a separate thread.
 
     The main client methods (execute, complete, etc.) all pass their arguments
     to the ioloop thread, which sends the messages. Handlers for received

--- a/jupyter_kernel_mgmt/client_base.py
+++ b/jupyter_kernel_mgmt/client_base.py
@@ -85,7 +85,7 @@ class ManagerClient(KernelManagerABC):
 
         Kernels can request to get interrupts as messages rather than signals.
         The manager is *not* expected to handle this.
-        :meth:`.KernelClient2.interrupt` should send an interrupt_request or
+        :meth:`.KernelClient.interrupt` should send an interrupt_request or
         call this method as appropriate.
         """
         msg = Message.from_type('interrupt_request', {})
@@ -110,7 +110,7 @@ class KernelClient(object):
     """Communicates with a single kernel on any host via zmq channels.
 
     The messages that can be sent are exposed as methods of the
-    client (KernelClient2.execute, complete, history, etc.). These methods only
+    client (KernelClient.execute, complete, history, etc.). These methods only
     send the message, they don't wait for a reply. To get results, use e.g.
     :meth:`get_shell_msg` to fetch messages from the shell channel.
     """

--- a/jupyter_kernel_mgmt/tests/test_client.py
+++ b/jupyter_kernel_mgmt/tests/test_client.py
@@ -1,4 +1,4 @@
-"""Tests for the KernelClient2"""
+"""Tests for the KernelClient"""
 
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.


### PR DESCRIPTION
Simple fix to replace `Client2` with `Client` in the comments.