### PR TITLE
Fix jupyter_kernel_mgmt.discovery main

### DIFF
--- a/jupyter_kernel_mgmt/discovery.py
+++ b/jupyter_kernel_mgmt/discovery.py
@@ -22,7 +22,8 @@ class KernelProviderBase(six.with_metaclass(ABCMeta, object)):
     id = None  # Should be a short string identifying the provider class.
 
     @abstractmethod
-    async def find_kernels(self):
+    @asyncio.coroutine
+    def find_kernels(self):
         """Return an iterator of (kernel_name, kernel_info_dict) tuples."""
         pass
 
@@ -192,12 +193,12 @@ class KernelFinder(object):
                        format(provider_id=provider_id, name=name))
 
 
-def main():
+async def find_kernels_from_entrypoints():
     kf = KernelFinder.from_entrypoints()
-    found_kernels = run_sync(kf.find_kernels())
+    found_kernels = kf.find_kernels()
     for type_id, info in found_kernels:
         print(type_id)
 
 
 if __name__ == '__main__':
-    main()
+    run_sync(find_kernels_from_entrypoints())

--- a/jupyter_kernel_mgmt/subproc/launcher.py
+++ b/jupyter_kernel_mgmt/subproc/launcher.py
@@ -10,13 +10,12 @@ import re
 import six
 import socket
 import stat
-from subprocess import PIPE, Popen
+from subprocess import PIPE
 import sys
 from traitlets.log import get_logger as get_app_logger
 import warnings
 
 from ipython_genutils.encoding import getdefaultencoding
-from ipython_genutils.py3compat import cast_bytes_py2
 from jupyter_core.paths import jupyter_runtime_dir, secure_write
 from jupyter_core.utils import ensure_dir_exists
 from ..localinterfaces import localhost, is_local_ip, local_ips
@@ -204,12 +203,9 @@ class SubprocessKernelLauncher:
         independent = False
 
         if sys.platform == 'win32':
-            # Popen on Python 2 on Windows cannot handle unicode args or cwd
-            encoding = getdefaultencoding(prefer_stream=False)
-            kwargs['args'] = [cast_bytes_py2(c, encoding) for c in cmd]
+            kwargs['args'] = cmd
             if self.cwd:
-                kwargs['cwd'] = cast_bytes_py2(self.cwd,
-                                        sys.getfilesystemencoding() or 'ascii')
+                kwargs['cwd'] = self.cwd
 
             try:
                 # noinspection PyUnresolvedReferences
@@ -237,10 +233,7 @@ class SubprocessKernelLauncher:
             # because we want to interrupt the whole process group.
             # We don't use setpgrp, which is known to cause problems for kernels starting
             # certain interactive subprocesses, such as bash -i.
-            if six.PY3:
-                kwargs['start_new_session'] = True
-            else:
-                kwargs['preexec_fn'] = lambda: os.setsid()
+            kwargs['start_new_session'] = True
             if not independent:
                 env['JPY_PARENT_PID'] = str(os.getpid())
 

--- a/jupyter_kernel_mgmt/tests/test_discovery.py
+++ b/jupyter_kernel_mgmt/tests/test_discovery.py
@@ -5,10 +5,13 @@
 
 import asyncio
 import logging
+import os
 import pytest
 import sys
 
 from os.path import join as pjoin
+from subprocess import Popen, PIPE, STDOUT
+
 from jupyter_kernel_mgmt import discovery, kernelspec
 from jupyter_kernel_mgmt.managerabc import KernelManagerABC
 from jupyter_kernel_mgmt.subproc.manager import KernelManager
@@ -272,3 +275,14 @@ async def test_load_config():
 
     assert count == 1
     assert found_argv == ['xxx', 'yyy']
+
+
+async def test_discovery_main(setup_test):
+    p = Popen(
+        [sys.executable, '-m', 'jupyter_kernel_mgmt.discovery'],
+        stdout=PIPE, stderr=STDOUT,
+        #env=os.environ,
+    )
+    out, err = p.communicate()
+    assert err is None
+    assert b'spec/sample' in out

--- a/jupyter_kernel_mgmt/tests/test_kernelapp.py
+++ b/jupyter_kernel_mgmt/tests/test_kernelapp.py
@@ -7,27 +7,17 @@ import sys
 from tempfile import mkdtemp
 import time
 
-PY3 = sys.version_info[0] >= 3
 
 def _launch(extra_env):
     env = os.environ.copy()
     env.update(extra_env)
     return Popen([sys.executable, '-c',
                   'from jupyter_client.kernelapp import main; main()'],
-                 env=env, stderr=(PIPE if PY3 else None))
+                 env=env, stderr=PIPE)
 
 WAIT_TIME = 10
 POLL_FREQ = 10
 
-def hacky_wait(p):
-    """Python 2 subprocess doesn't have timeouts :-("""
-    for _ in range(WAIT_TIME * POLL_FREQ):
-        if p.poll() is not None:
-            return p.returncode
-        time.sleep(1 / POLL_FREQ)
-    else:
-        raise AssertionError("Process didn't exit in {} seconds"
-                             .format(WAIT_TIME))
 
 def test_kernelapp_lifecycle():
     # Check that 'jupyter kernel' starts and terminates OK.
@@ -56,11 +46,8 @@ def test_kernelapp_lifecycle():
 
         # Send SIGTERM to shut down
         p.terminate()
-        if PY3:
-            _, stderr = p.communicate(timeout=WAIT_TIME)
-            assert cf in stderr.decode('utf-8', 'replace')
-        else:
-            hacky_wait(p)
+        _, stderr = p.communicate(timeout=WAIT_TIME)
+        assert cf in stderr.decode('utf-8', 'replace')
     finally:
         shutil.rmtree(runtime_dir)
         shutil.rmtree(startup_dir)


### PR DESCRIPTION
The __main__ entrypoint in discovery.py wasn't correctly modified to
deal with the async changes. A test has been added to validate this.

Took this opportunity for the following cleanup...
1. Properly decorated find_kernels() in the abstract base class.
2. Cleanup/remove some Python 2 remnants.

Fixes #27