### PR TITLE
Fix launch on windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 python:
+    - 3.8
+    - 3.7
     - 3.6
-    - 3.5
 install:
   - pip install --upgrade setuptools pip
   - pip install --upgrade -e .[test] pytest-cov codecov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,23 @@
+matrix:
+  fast_finish: true
+
+environment:
+  matrix:
+  - CONDA_PY: 37
+    CONDA_INSTALL_LOCN: '"C:\\Miniconda36-x64"'
+
+platform:
+  - x64
+
+build: off
+
+install:
+  - cmd: call %CONDA_INSTALL_LOCN%\\Scripts\\activate.bat
+  - cmd: conda config --set show_channel_urls true
+  - cmd: conda config --add channels conda-forge
+  - cmd: conda install -y python=3.7 pyzmq tornado nbformat nbconvert ipykernel pip 
+  - cmd: pip install .[test]
+  - cmd: pip install --upgrade jupyter_core  # latest core not on conda yet
+
+test_script:
+  - pytest -v jupyter_kernel_mgmt/tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,13 @@
-matrix:
-  fast_finish: true
-
 environment:
   matrix:
-    - CONDA_PY: 38
-      CONDA_PY_SPEC: ">=3.8,<3.9.0a0"
+    - CONDA_PY: 36
+      CONDA_PY_SPEC: 3.6
       CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
     - CONDA_PY: 37
-      CONDA_PY_SPEC: ">=3.7,<3.8.0a0"
+      CONDA_PY_SPEC: 3.7
+      CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
+    - CONDA_PY: 38
+      CONDA_PY_SPEC: 3.8
       CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
 
 platform:
@@ -17,11 +17,17 @@ build: off
 
 install:
   - cmd: call %CONDA_INSTALL_LOCN%\\Scripts\\activate.bat
+  - cmd: set CONDA_PY=%CONDA_PY%
+  - cmd: set CONDA_PY_SPEC=%CONDA_PY_SPEC%
   - cmd: conda config --set show_channel_urls true
   - cmd: conda config --add channels conda-forge
-  - cmd: conda install -y python=%CONDA_PY_SPEC% pyzmq tornado nbformat nbconvert ipykernel pip
+  - cmd: conda update -y -q conda
+  - cmd: conda info -a
+  - cmd: conda create -y -q -n test-env-%CONDA_PY% python=%CONDA_PY_SPEC% pyzmq tornado nbformat nbconvert ipykernel pip
+  - cmd: conda activate test-env-%CONDA_PY%
   - cmd: pip install .[test]
-  - cmd: pip install --upgrade jupyter_core  # latest core not on conda yet
+# FIXME: Use minrk's patch for python 3.8, windows issues.  Remove once released.
+  - IF %CONDA_PY% == 38 pip install --upgrade git+https://github.com/minrk/ipykernel.git@py38-win
 
 test_script:
   - pytest -v jupyter_kernel_mgmt/tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,8 +3,12 @@ matrix:
 
 environment:
   matrix:
-  - CONDA_PY: 37
-    CONDA_INSTALL_LOCN: '"C:\\Miniconda36-x64"'
+    - CONDA_PY: 38
+      CONDA_PY_SPEC: ">=3.8,<3.9.0a0"
+      CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
+    - CONDA_PY: 37
+      CONDA_PY_SPEC: ">=3.7,<3.8.0a0"
+      CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
 
 platform:
   - x64
@@ -15,7 +19,7 @@ install:
   - cmd: call %CONDA_INSTALL_LOCN%\\Scripts\\activate.bat
   - cmd: conda config --set show_channel_urls true
   - cmd: conda config --add channels conda-forge
-  - cmd: conda install -y python=3.7 pyzmq tornado nbformat nbconvert ipykernel pip 
+  - cmd: conda install -y python=%CONDA_PY_SPEC% pyzmq tornado nbformat nbconvert ipykernel pip
   - cmd: pip install .[test]
   - cmd: pip install --upgrade jupyter_core  # latest core not on conda yet
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,8 +26,8 @@ install:
   - cmd: conda create -y -q -n test-env-%CONDA_PY% python=%CONDA_PY_SPEC% pyzmq tornado nbformat nbconvert ipykernel pip
   - cmd: conda activate test-env-%CONDA_PY%
   - cmd: pip install .[test]
-# FIXME: Use minrk's patch for python 3.8, windows issues.  Remove once released.
-  - IF %CONDA_PY% == 38 pip install --upgrade git+https://github.com/minrk/ipykernel.git@py38-win
+# FIXME: Use patch for python 3.8, windows issues (https://github.com/ipython/ipykernel/pull/456) - remove once released
+  - IF %CONDA_PY% == 38 pip install --upgrade git+https://github.com/ipython/ipykernel.git
 
 test_script:
   - pytest -v jupyter_kernel_mgmt/tests

--- a/jupyter_kernel_mgmt/managerabc.py
+++ b/jupyter_kernel_mgmt/managerabc.py
@@ -18,12 +18,9 @@ class KernelManagerABC(six.with_metaclass(ABCMeta, object)):
         pass
 
     @abstractmethod
-    async def wait(self, timeout):
+    async def wait(self):
         """
         Wait for the kernel process to exit.
-
-        If timeout is a number, it is a maximum time in seconds to wait.
-        timeout=None means wait indefinitely.
 
         Returns True if the kernel is still alive after waiting, False if it
         exited (like is_alive()).

--- a/jupyter_kernel_mgmt/subproc/launcher.py
+++ b/jupyter_kernel_mgmt/subproc/launcher.py
@@ -251,6 +251,16 @@ class SubprocessKernelLauncher:
                                          DUPLICATE_SAME_ACCESS)
                 env['JPY_PARENT_PID'] = str(int(handle))
 
+            # Prevent creating new console window on pythonw
+            if redirect_out:
+                kwargs['creationflags'] = kwargs.setdefault('creationflags', 0) | 0x08000000 # CREATE_NO_WINDOW
+
+            # Avoid closing the above parent and interrupt handles.
+            # close_fds is True by default on Python >=3.7
+            # or when no stream is captured on Python <3.7
+            # (we always capture stdin, so this is already False by default on <3.7)
+            kwargs['close_fds'] = False
+
         else:
             kwargs['args'] = cmd
             kwargs['cwd'] = self.cwd

--- a/jupyter_kernel_mgmt/subproc/launcher.py
+++ b/jupyter_kernel_mgmt/subproc/launcher.py
@@ -7,23 +7,32 @@ import errno
 import json
 import os
 import re
-import six
 import socket
 import stat
-from subprocess import PIPE
+from subprocess import PIPE, Popen
 import sys
 from traitlets.log import get_logger as get_app_logger
 import warnings
 
-from ipython_genutils.encoding import getdefaultencoding
 from jupyter_core.paths import jupyter_runtime_dir, secure_write
 from jupyter_core.utils import ensure_dir_exists
 from ..localinterfaces import localhost, is_local_ip, local_ips
-from .manager import KernelManager
+from .manager import KernelManager, use_sync_subprocess
 from ..util import run_sync
 
-port_names = ['shell_port', 'iopub_port', 'stdin_port', 'control_port',
-              'hb_port']
+port_names = ['shell_port', 'iopub_port', 'stdin_port', 'control_port', 'hb_port']
+
+if sys.platform == 'win32':
+    # Windows specific event-loop policy.  Although WindowsSelectorEventLoop is the current
+    # default event loop priot to Python 3.8, WindowsProactorEventLoop becomes the default
+    # in Python 3.8.  However, using WindowsProactorEventLoop fails during creation of
+    # IOLoopKernelClient because it doesn't implement add_reader(), while using
+    # WindowsSelectorEventLoop fails during asyncio.create_subprocess_exec() because it
+    # doesn't implement _make_subprocess_transport().  As a result, we need to force the use of
+    # the WindowsSelectorEventLoop, and essentially make process management synchronous on Windows
+    # (via use_sync_subprocess). (sigh)
+    # See https://github.com/takluyver/jupyter_kernel_mgmt/issues/31
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 
 class SubprocessKernelLauncher:
@@ -76,7 +85,11 @@ class SubprocessKernelLauncher:
         # launch the kernel subprocess
         args = kw.pop('args')
         self.log.debug("Starting kernel cmd: %s", args)
-        kernel = await asyncio.create_subprocess_exec(*args, **kw)
+
+        if use_sync_subprocess:
+            kernel = Popen(args, **kw)
+        else:
+            kernel = await asyncio.create_subprocess_exec(*args, **kw)
         kernel.stdin.close()
 
         files_to_cleanup = list(self.files_to_cleanup(conn_file, conn_info))
@@ -325,7 +338,7 @@ def prepare_interrupt_event(env, interrupt_event=None):
 
 
 async def start_new_kernel(kernel_cmd, startup_timeout=60, cwd=None, launch_params=None):
-    """Start a new kernel, and return its Manager and a blocking client"""
+    """Start a new kernel, and return its Manager and a client"""
     from ..client import IOLoopKernelClient
     cwd = cwd or os.getcwd()
 
@@ -336,7 +349,7 @@ async def start_new_kernel(kernel_cmd, startup_timeout=60, cwd=None, launch_para
         await asyncio.wait_for(kc.wait_for_ready(), timeout=startup_timeout)
     except RuntimeError:
         await kc.shutdown_or_terminate()
-        await kc.close()
+        kc.close()
         raise
 
     return km, kc

--- a/jupyter_kernel_mgmt/subproc/manager.py
+++ b/jupyter_kernel_mgmt/subproc/manager.py
@@ -30,7 +30,7 @@ class KernelManager(KernelManagerABC):
 
     popen : subprocess.Popen or asyncio.subprocess.Process
       The process with the started kernel.  Windows will use
-      Popen (by default), while non-Windows will will asyncio's Process
+      Popen (by default), while non-Windows will use asyncio's Process.
     files_to_cleanup : list of paths, optional
       Files to be cleaned up after terminating this kernel.
     win_interrupt_evt :
@@ -141,10 +141,4 @@ class KernelManager(KernelManagerABC):
         if self.async_subprocess:
             return not self._exit_future.done()
         else:
-            is_alive = False  # assume the kernel is dead
-            if self.kernel is not None:
-                if self.kernel.poll() is None:
-                    is_alive = True
-
-            return is_alive
-
+            return self.kernel and (self.kernel.poll() is None)

--- a/jupyter_kernel_mgmt/tests/conftest.py
+++ b/jupyter_kernel_mgmt/tests/conftest.py
@@ -1,11 +1,19 @@
 import os
-pjoin = os.path.join
 import pytest
-import sys
+from ..util import _init_asyncio_patch
+
+pjoin = os.path.join
+
 
 @pytest.fixture
-def setup_env(tmpdir, monkeypatch):
+def asyncio_patch():
+    _init_asyncio_patch()
+
+
+@pytest.fixture
+def setup_env(tmpdir, monkeypatch, asyncio_patch):
     monkeypatch.setenv('JUPYTER_CONFIG_DIR', pjoin(tmpdir.dirname, 'jupyter'))
     monkeypatch.setenv('JUPYTER_DATA_DIR', pjoin(tmpdir.dirname, 'jupyter_data'))
     monkeypatch.setenv('JUPYTER_RUNTIME_DIR', pjoin(tmpdir.dirname, 'jupyter_runtime'))
     monkeypatch.setenv('IPYTHONDIR', pjoin(tmpdir.dirname, 'ipython'))
+

--- a/jupyter_kernel_mgmt/tests/test_async_manager.py
+++ b/jupyter_kernel_mgmt/tests/test_async_manager.py
@@ -10,7 +10,8 @@ TIMEOUT = 10
 
 pytestmark = pytest.mark.asyncio
 
-async def test_get_connect_info():
+
+async def test_get_connect_info(asyncio_patch):
     launcher = SubprocessKernelLauncher(make_ipkernel_cmd(), os.getcwd())
     info, km = await launcher.launch()
     try:
@@ -23,7 +24,8 @@ async def test_get_connect_info():
         await km.kill()
         await km.cleanup()
 
-async def test_start_new_kernel():
+
+async def test_start_new_kernel(asyncio_patch):
     km, kc = await start_new_kernel(make_ipkernel_cmd(), startup_timeout=TIMEOUT)
     try:
         assert await km.is_alive()

--- a/jupyter_kernel_mgmt/tests/test_discovery.py
+++ b/jupyter_kernel_mgmt/tests/test_discovery.py
@@ -150,7 +150,7 @@ def setup_test(setup_env):
                           kernel_json=params_json)
 
 
-async def test_ipykernel_provider():
+async def test_ipykernel_provider(setup_test):
     import ipykernel  # Fail clearly if ipykernel not installed
     ikf = discovery.IPykernelProvider()
 
@@ -161,7 +161,7 @@ async def test_ipykernel_provider():
     assert info['argv'][0] == sys.executable
 
 
-async def test_meta_kernel_finder():
+async def test_meta_kernel_finder(setup_test):
     kf = discovery.KernelFinder(providers=[DummyKernelProvider()])
     assert list(kf.find_kernels()) == \
         [('dummy/sample', {'argv': ['dummy_kernel']})]
@@ -258,7 +258,7 @@ async def test_kernel_launch_params(caplog, setup_test):
         await manager.kill()
 
 
-async def test_load_config():
+async def test_load_config(setup_test):
     # create fake application
     app = ProviderApplication()
     app.launch_instance(argv=["--ProviderConfig.my_argv=['xxx','yyy']"])

--- a/jupyter_kernel_mgmt/tests/test_kernelapp.py
+++ b/jupyter_kernel_mgmt/tests/test_kernelapp.py
@@ -19,7 +19,7 @@ WAIT_TIME = 10
 POLL_FREQ = 10
 
 
-def test_kernelapp_lifecycle():
+def test_kernelapp_lifecycle(setup_env):
     # Check that 'jupyter kernel' starts and terminates OK.
     runtime_dir = mkdtemp()
     startup_dir = mkdtemp()

--- a/jupyter_kernel_mgmt/tests/test_kernelspec.py
+++ b/jupyter_kernel_mgmt/tests/test_kernelspec.py
@@ -15,11 +15,6 @@ import sys
 
 import pytest
 
-if str is bytes: # py2
-    StringIO = io.BytesIO
-else:
-    StringIO = io.StringIO
-
 from ipython_genutils.tempdir import TemporaryDirectory
 from jupyter_kernel_mgmt import kernelspec
 from jupyter_core import paths
@@ -117,7 +112,7 @@ def test_install_kernel_spec(ksm, installable_kernel):
 
 
 def test_install_kernel_spec_prefix(tmpdir, ksm, installable_kernel):
-    capture = StringIO()
+    capture = io.StringIO()
     handler = StreamHandler(capture)
     ksm.log.addHandler(handler)
     ksm.install_kernel_spec(installable_kernel,
@@ -133,7 +128,7 @@ def test_install_kernel_spec_prefix(tmpdir, ksm, installable_kernel):
     assert 'tstinstalled' in ksm.find_kernel_specs()
 
     # Run it again, no warning this time because we've added it to the path
-    capture = StringIO()
+    capture = io.StringIO()
     handler = StreamHandler(capture)
     ksm.log.addHandler(handler)
     ksm.install_kernel_spec(installable_kernel,

--- a/jupyter_kernel_mgmt/tests/test_localinterfaces.py
+++ b/jupyter_kernel_mgmt/tests/test_localinterfaces.py
@@ -7,7 +7,8 @@
 
 from .. import localinterfaces
 
-def test_load_ips():
+
+def test_load_ips(setup_env):
     # Override the machinery that skips it if it was called before
     localinterfaces._load_ips.called = False
 

--- a/jupyter_kernel_mgmt/tests/test_restarter.py
+++ b/jupyter_kernel_mgmt/tests/test_restarter.py
@@ -12,7 +12,7 @@ from jupyter_kernel_mgmt.restarter import KernelRestarterBase
 
 
 @pytest.mark.asyncio
-async def test_reinstantiate():
+async def test_reinstantiate(setup_env):
     # If the kernel fails, a new manager should be instantiated
     kf = discovery.KernelFinder(providers=[DummyKernelProvider()])
     _, manager = await kf.launch('dummy/sample')

--- a/jupyter_kernel_mgmt/util.py
+++ b/jupyter_kernel_mgmt/util.py
@@ -4,6 +4,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 import asyncio
+import sys
 
 
 def inherit_docstring(cls):
@@ -16,3 +17,31 @@ def inherit_docstring(cls):
 
 def run_sync(coro_method):
     return asyncio.get_event_loop().run_until_complete(coro_method)
+
+
+def _init_asyncio_patch():
+    if sys.platform.startswith("win"): # and sys.version_info >= (3, 8):
+        # Windows specific event-loop policy.  Although WindowsSelectorEventLoop is the current
+        # default event loop priot to Python 3.8, WindowsProactorEventLoop becomes the default
+        # in Python 3.8.  However, using WindowsProactorEventLoop fails during creation of
+        # IOLoopKernelClient because it doesn't implement add_reader(), while using
+        # WindowsSelectorEventLoop fails during asyncio.create_subprocess_exec() because it
+        # doesn't implement _make_subprocess_transport().  As a result, we need to force the use of
+        # the WindowsSelectorEventLoop, and essentially make process management synchronous on Windows
+        # (via use_sync_subprocess). (sigh)
+        # See https://github.com/takluyver/jupyter_kernel_mgmt/issues/31
+        # The following approach to this is from https://github.com/jupyter/notebook/pull/5047 by @minrk
+        try:
+            from asyncio import (
+                WindowsProactorEventLoopPolicy,
+                WindowsSelectorEventLoopPolicy,
+            )
+        except ImportError:
+            pass
+            # not affected
+        else:
+            if type(asyncio.get_event_loop_policy()) is WindowsProactorEventLoopPolicy:
+                # WindowsProactorEventLoopPolicy is not compatible with tornado 6
+                # fallback to the pre-3.8 default of Selector
+                asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolicy())
+            print(asyncio.get_event_loop_policy())


### PR DESCRIPTION
Due to event loop implementation differences (see #31), we need to "pin"
the SelectorEventLoop for Windows platforms and use synchronous popen/wait
constructs.  Although non-windows platforms will use async constructs,
that decision is maintained in a variable so we can easily change behavior.

@takluyver - I've also added `appveyor.yml`.  It would be great if you could configure appveyor for the repo.

Fixes #31