### PR TITLE
Fix syntax error to enable support for python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
     - 3.8
     - 3.7
     - 3.6
+    - 3.5
 install:
   - pip install --upgrade setuptools pip
   - pip install --upgrade -e .[test] pytest-cov codecov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,8 @@
 environment:
   matrix:
+    - CONDA_PY: 35
+      CONDA_PY_SPEC: 3.5
+      CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
     - CONDA_PY: 36
       CONDA_PY_SPEC: 3.6
       CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"

--- a/jupyter_kernel_mgmt/hl.py
+++ b/jupyter_kernel_mgmt/hl.py
@@ -47,7 +47,7 @@ class run_kernel_async:
 
 
 def start_kernel_blocking(
-        name, *, cwd=None, launch_params=None, finder=None, startup_timeout=60,
+        name, *, cwd=None, launch_params=None, finder=None, startup_timeout=60
 ):
     """Start a kernel by kernel type name, return (manager, blocking client)"""
     kf = finder or KernelFinder.from_entrypoints()


### PR DESCRIPTION
Since clients of juptyer_server will need to support py3.5, we should
to do the same given JKM's primary application will be jupyter_server.
This change fixes the syntax error and adds 3.5 to test matrices.