### PR TITLE
[WIP] Fix kernelapp

### DIFF
--- a/jupyter_kernel_mgmt/tests/test_kernelapp.py
+++ b/jupyter_kernel_mgmt/tests/test_kernelapp.py
@@ -6,27 +6,28 @@ from subprocess import Popen, PIPE
 import sys
 from tempfile import mkdtemp
 import time
+import json
 
 
 def _launch(extra_env):
     env = os.environ.copy()
     env.update(extra_env)
     return Popen([sys.executable, '-c',
-                  'from jupyter_client.kernelapp import main; main()'],
+                  'from jupyter_kernel_mgmt.kernelapp import main; main()'],
                  env=env, stderr=PIPE)
 
-WAIT_TIME = 10
+
+WAIT_TIME = 20
 POLL_FREQ = 10
 
 
 def test_kernelapp_lifecycle(setup_env):
     # Check that 'jupyter kernel' starts and terminates OK.
-    runtime_dir = mkdtemp()
+    runtime_dir = os.getenv('JUPYTER_RUNTIME_DIR')  # already temp via setup_env fixture
     startup_dir = mkdtemp()
     started = os.path.join(startup_dir, 'started')
     try:
-        p = _launch({'JUPYTER_RUNTIME_DIR': runtime_dir,
-                     'JUPYTER_CLIENT_TEST_RECORD_STARTUP_PRIVATE': started,
+        p = _launch({'JUPYTER_CLIENT_TEST_RECORD_STARTUP_PRIVATE': started,
                     })
         # Wait for start
         for _ in range(WAIT_TIME * POLL_FREQ):
@@ -44,11 +45,20 @@ def test_kernelapp_lifecycle(setup_env):
         assert cf.startswith('kernel')
         assert cf.endswith('.json')
 
+        # since the connection file is no longer displayed by the application
+        # (connection info is dumped instead), we'll open the connection file
+        # and pick out the entry for hb_port, then build an applicably-formatted
+        # string to assert it's in stderr.
+
+        connection_file = os.path.join(runtime_dir, cf)
+        with open(connection_file) as file:
+            connection_info = json.load(file)
+            hb_port_info = "'hb_port': " + str(connection_info['hb_port'])
+
         # Send SIGTERM to shut down
         p.terminate()
         _, stderr = p.communicate(timeout=WAIT_TIME)
-        assert cf in stderr.decode('utf-8', 'replace')
+        assert hb_port_info in stderr.decode('utf-8', 'replace')
     finally:
-        shutil.rmtree(runtime_dir)
         shutil.rmtree(startup_dir)
 


### PR DESCRIPTION
These changes update kernelapp to be _closer_ to what they should
be (tests passes), but the application still doesn't work correctly.

Problem areas:
1. The connection file is no longer on the kernel manager instance, and the launch method returns the connection information (not a file), so logging the connection file name along with a hit to use `--existing` isn't applicable.  I have just dumped the connection info, but that's probably a security violation now that I thin about ti.
2. Need to run some async methods using the run_sync() utility method.  There are probably issues in this area.
3. Event loop already running issues...

When I run `python -c "from jupyter_kernel_mgmt.kernelapp import main; main()"` from the command line, I see the following (which seems correct)...
```
[KernelApp] Starting kernel 'pyimport/kernel'
[KernelApp] Connection information: {'shell_port': 56018, 'iopub_port': 56019, 'stdin_port': 56020, 'control_port': 56021, 'hb_port': 56022, 'ip': '127.0.0.1', 'key': '37575c3f-e6744a55aecfd4a3f4bccbd7', 'transport': 'tcp', 'signature_scheme': 'hmac-sha256'}
```
I then locate the process id (essentially simulating what the test is doing) and issue `kill pid`, then get the following...
```
[KernelApp] Shutting down on signal 15
ERROR:tornado.application:Exception in callback functools.partial(<bound method KernelApp.shutdown of <jupyter_kernel_mgmt.kernelapp.KernelApp object at 0x10c876588>>, 15)
Traceback (most recent call last):
  File "/opt/anaconda3/envs/kernel-mgmt-dev/lib/python3.6/site-packages/tornado/ioloop.py", line 743, in _run_callback
    ret = callback()
  File "/Users/kbates/repos/oss/gateway-experiments/jupyter_kernel_mgmt/jupyter_kernel_mgmt/kernelapp.py", line 52, in shutdown
    client.wait_for_ready()
  File "/Users/kbates/repos/oss/gateway-experiments/jupyter_kernel_mgmt/jupyter_kernel_mgmt/client.py", line 407, in wait_for_ready
    loop.run_sync(lambda: self.loop_client.wait_for_ready(), timeout=timeout)
  File "/opt/anaconda3/envs/kernel-mgmt-dev/lib/python3.6/site-packages/tornado/ioloop.py", line 526, in run_sync
    self.start()
  File "/opt/anaconda3/envs/kernel-mgmt-dev/lib/python3.6/site-packages/tornado/platform/asyncio.py", line 148, in start
    self.asyncio_loop.run_forever()
  File "/opt/anaconda3/envs/kernel-mgmt-dev/lib/python3.6/asyncio/base_events.py", line 409, in run_forever
    raise RuntimeError('This event loop is already running')
RuntimeError: This event loop is already running
[IPKernelApp] WARNING | Parent appears to have exited, shutting down.
```
So although the test "passes", these issues are masked.

Fixes: #40