### PR TITLE
Fix kernelapp (continued)

### DIFF
--- a/jupyter_kernel_mgmt/client.py
+++ b/jupyter_kernel_mgmt/client.py
@@ -58,6 +58,13 @@ class IOLoopKernelClient(KernelClient):
         if DEBUG_LOGGING:
             self.add_handler(self._debug_log, {'iopub', 'shell', 'stdin', 'control'})
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        return False
+
     def close(self):
         """Close the client's sockets & streams.
 

--- a/jupyter_kernel_mgmt/kernelapp.py
+++ b/jupyter_kernel_mgmt/kernelapp.py
@@ -63,7 +63,7 @@ class KernelApp:
 
         Do not rely on this except in our own tests!
         """
-        fn = os.environ.get('JUPYTER_CLIENT_TEST_RECORD_STARTUP_PRIVATE')
+        fn = os.environ.get('JKM_TEST_RECORD_STARTUP_PRIVATE')
         if fn is not None:
             with open(fn, 'wb'):
                 pass

--- a/jupyter_kernel_mgmt/kernelapp.py
+++ b/jupyter_kernel_mgmt/kernelapp.py
@@ -1,39 +1,29 @@
+import asyncio
+import argparse
+import json
+import logging
 import os
 import signal
+from uuid import uuid4
 
-from jupyter_core.application import JupyterApp, base_flags
-from tornado.ioloop import IOLoop
-from traitlets import Unicode
+from jupyter_core.paths import jupyter_runtime_dir, secure_write
+from jupyter_core.utils import ensure_dir_exists
 
 from . import __version__
 from .discovery import KernelFinder
-from .client import BlockingKernelClient
-from .util import run_sync
+from .client import IOLoopKernelClient
+
+log = logging.getLogger(__name__)
 
 
-class KernelApp(JupyterApp):
+class KernelApp:
     """Launch a kernel by kernel type ID
     """
-    version = __version__
-    description = "Run a kernel by kernel type ID"
-
-    aliases = {
-        'kernel': 'KernelApp.kernel_name',
-        #'ip': 'KernelManager.ip', # TODO
-    }
-    flags = {'debug': base_flags['debug']}
-
-    kernel_name = Unicode("pyimport/kernel",
-        help = 'The name of a kernel type to start'
-    ).tag(config=True)
-
-    def initialize(self, argv=None):
-        super(KernelApp, self).initialize(argv)
-        self.kernel_finder = KernelFinder.from_entrypoints()
-        if '/' not in self.kernel_name:
-            self.kernel_name = 'spec/' + self.kernel_name
-        self.loop = IOLoop.current()
-        self.loop.add_callback(self._record_started)
+    def __init__(self, kernel_name='pyimport/kernel'):
+        if '/' not in kernel_name:
+            kernel_name = 'spec/' + kernel_name
+        self.kernel_name = kernel_name
+        self.shutdown_event = asyncio.Event()
 
     def setup_signals(self):
         """Shutdown on SIGTERM or SIGINT (Ctrl-C)"""
@@ -41,23 +31,28 @@ class KernelApp(JupyterApp):
             return
 
         def shutdown_handler(signo, frame):
-            self.loop.add_callback_from_signal(self.shutdown, signo)
+            log.info('Shutting down on signal %d' % signo)
+            self.shutdown_event.set()
         for sig in [signal.SIGTERM, signal.SIGINT]:
             signal.signal(sig, shutdown_handler)
 
-    def shutdown(self, signo):
-        self.log.info('Shutting down on signal %d' % signo)
-        client = BlockingKernelClient(self.connection_info,
-                                      manager=self.manager)
-        client.wait_for_ready()
-        client.shutdown_or_terminate()
-        client.close()
-        self.loop.stop()
+    async def shutdown(self, conn_info, manager):
+        log.info("Shutting down kernel...")
+        with IOLoopKernelClient(conn_info, manager=manager) as client:
+            await client.shutdown_or_terminate()
 
-    def log_connection_info(self):
-        cf = self.connection_info
-        self.log.info('Connection information: %s', cf)
-        #self.log.info("To connect a client: --existing %s", os.path.basename(cf))
+    def record_connection_info(self, conn_info):
+        runtime_dir = jupyter_runtime_dir()
+        ensure_dir_exists(runtime_dir)
+        fname = os.path.join(runtime_dir, 'kernel-%s.json' % uuid4())
+
+        # Only ever write this file as user read/writeable
+        # This would otherwise introduce a vulnerability as a file has secrets
+        # which would let others execute arbitrarily code as you
+        with secure_write(fname) as f:
+            f.write(json.dumps(conn_info, indent=2))
+
+        log.info("To connect a client: --existing %s", os.path.basename(fname))
 
     def _record_started(self):
         """For tests, create a file to indicate that we've started
@@ -69,15 +64,40 @@ class KernelApp(JupyterApp):
             with open(fn, 'wb'):
                 pass
 
-    def start(self):
-        self.log.info('Starting kernel %r', self.kernel_name)
-        self.connection_info, self.manager = run_sync(self.kernel_finder.launch(self.kernel_name))
+    async def run_in_loop(self):
+        log.info('Starting kernel %r', self.kernel_name)
+        kernel_finder = KernelFinder.from_entrypoints()
+        conn_info, mgr = await kernel_finder.launch(self.kernel_name)
         try:
-            self.log_connection_info()
+            self._record_started()
+            self.record_connection_info(conn_info)
             self.setup_signals()
-            self.loop.start()
+            await asyncio.wait(
+                [self.shutdown_event.wait(), mgr.wait()],
+                return_when=asyncio.FIRST_COMPLETED
+            )
         finally:
-            run_sync(self.manager.cleanup())
+            if await mgr.is_alive():
+                await self.shutdown(conn_info, mgr)
+            await mgr.cleanup()
+
+    def run(self):
+        asyncio.get_event_loop().run_until_complete(self.run_in_loop())
 
 
-main = KernelApp.launch_instance
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        'jupyter-kernel', description="Run a kernel by kernel type ID"
+    )
+    ap.add_argument('--version', action='version', version=__version__)
+    ap.add_argument('--kernel', default='pyimport/kernel',
+        help="Kernel type to launch"
+    )
+    args = ap.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO)
+
+    return KernelApp(args.kernel).run()
+
+if __name__ == '__main__':
+    main()

--- a/jupyter_kernel_mgmt/kernelapp.py
+++ b/jupyter_kernel_mgmt/kernelapp.py
@@ -42,6 +42,7 @@ class KernelApp:
             await client.shutdown_or_terminate()
 
     def record_connection_info(self, conn_info):
+        log.info("Connection info: %s", conn_info)
         runtime_dir = jupyter_runtime_dir()
         ensure_dir_exists(runtime_dir)
         fname = os.path.join(runtime_dir, 'kernel-%s.json' % uuid4())

--- a/jupyter_kernel_mgmt/kernelapp.py
+++ b/jupyter_kernel_mgmt/kernelapp.py
@@ -30,11 +30,13 @@ class KernelApp:
         if os.name == 'nt':
             return
 
-        def shutdown_handler(signo, frame):
+        def shutdown_handler(signo):
             log.info('Shutting down on signal %d' % signo)
             self.shutdown_event.set()
+
+        loop = asyncio.get_event_loop()
         for sig in [signal.SIGTERM, signal.SIGINT]:
-            signal.signal(sig, shutdown_handler)
+            loop.add_signal_handler(sig, shutdown_handler, sig)
 
     async def shutdown(self, conn_info, manager):
         log.info("Shutting down kernel...")

--- a/jupyter_kernel_mgmt/kernelapp.py
+++ b/jupyter_kernel_mgmt/kernelapp.py
@@ -73,8 +73,8 @@ class KernelApp:
         kernel_finder = KernelFinder.from_entrypoints()
         conn_info, mgr = await kernel_finder.launch(self.kernel_name)
         try:
-            self._record_started()
             conn_file = self.record_connection_info(conn_info)
+            self._record_started()
             self.setup_signals()
             await asyncio.wait(
                 [self.shutdown_event.wait(), mgr.wait()],

--- a/jupyter_kernel_mgmt/tests/test_discovery.py
+++ b/jupyter_kernel_mgmt/tests/test_discovery.py
@@ -192,6 +192,7 @@ async def test_kernel_spec_provider(setup_test):
     assert isinstance(manager, KernelManager)
     # this actually starts a kernel, so let's make sure its terminated
     await manager.kill()
+    await manager.cleanup()
 
 
 async def test_kernel_spec_provider_subclass(setup_test):
@@ -256,6 +257,7 @@ async def test_kernel_launch_params(caplog, setup_test):
 
         # this actually starts a tail -f command, so let's make sure its terminated
         await manager.kill()
+        await manager.cleanup()
 
 
 async def test_load_config(setup_test):

--- a/jupyter_kernel_mgmt/tests/test_kernelapp.py
+++ b/jupyter_kernel_mgmt/tests/test_kernelapp.py
@@ -39,11 +39,13 @@ def test_kernelapp_lifecycle(setup_env):
                                  .format(WAIT_TIME))
 
         # Connection file should be there by now
+        # TODO: now there are 2 connection files (1 to launch the kernel, 1 to
+        # advertise it). Clean this up when we have a better solution.
         files = os.listdir(runtime_dir)
-        assert len(files) == 1
-        cf = files[0]
-        assert cf.startswith('kernel')
-        assert cf.endswith('.json')
+        assert len(files) == 2
+        for cf in files:
+            assert cf.startswith('kernel')
+            assert cf.endswith('.json')
 
         # since the connection file is no longer displayed by the application
         # (connection info is dumped instead), we'll open the connection file

--- a/jupyter_kernel_mgmt/tests/test_kernelapp.py
+++ b/jupyter_kernel_mgmt/tests/test_kernelapp.py
@@ -27,7 +27,7 @@ def test_kernelapp_lifecycle(setup_env):
     startup_dir = mkdtemp()
     started = os.path.join(startup_dir, 'started')
     try:
-        p = _launch({'JUPYTER_CLIENT_TEST_RECORD_STARTUP_PRIVATE': started,
+        p = _launch({'JKM_TEST_RECORD_STARTUP_PRIVATE': started,
                     })
         # Wait for start
         for _ in range(WAIT_TIME * POLL_FREQ):

--- a/jupyter_kernel_mgmt/tests/test_kernelapp.py
+++ b/jupyter_kernel_mgmt/tests/test_kernelapp.py
@@ -6,27 +6,28 @@ from subprocess import Popen, PIPE
 import sys
 from tempfile import mkdtemp
 import time
+import json
 
 
 def _launch(extra_env):
     env = os.environ.copy()
     env.update(extra_env)
     return Popen([sys.executable, '-c',
-                  'from jupyter_client.kernelapp import main; main()'],
+                  'from jupyter_kernel_mgmt.kernelapp import main; main()'],
                  env=env, stderr=PIPE)
 
-WAIT_TIME = 10
+
+WAIT_TIME = 20
 POLL_FREQ = 10
 
 
 def test_kernelapp_lifecycle(setup_env):
     # Check that 'jupyter kernel' starts and terminates OK.
-    runtime_dir = mkdtemp()
+    runtime_dir = os.getenv('JUPYTER_RUNTIME_DIR')  # already temp via setup_env fixture
     startup_dir = mkdtemp()
     started = os.path.join(startup_dir, 'started')
     try:
-        p = _launch({'JUPYTER_RUNTIME_DIR': runtime_dir,
-                     'JUPYTER_CLIENT_TEST_RECORD_STARTUP_PRIVATE': started,
+        p = _launch({'JUPYTER_CLIENT_TEST_RECORD_STARTUP_PRIVATE': started,
                     })
         # Wait for start
         for _ in range(WAIT_TIME * POLL_FREQ):
@@ -44,11 +45,20 @@ def test_kernelapp_lifecycle(setup_env):
         assert cf.startswith('kernel')
         assert cf.endswith('.json')
 
+        # since the connection file is no longer displayed by the application
+        # (connection info is dumped instead), we'll open the connection file
+        # and pick out the entry for hb_port, then build an applicably-formatted
+        # string to assert it's in stderr.
+
+        connection_file = os.path.join(runtime_dir, cf)
+        with open(connection_file) as file:
+            connection_info = json.load(file)
+            hb_port_info = "'hb_port': " + str(connection_info['hb_port'])
+
         # Send SIGTERM to shut down
         p.terminate()
         _, stderr = p.communicate(timeout=WAIT_TIME)
-        assert cf in stderr.decode('utf-8', 'replace')
+        assert hb_port_info in stderr.decode('utf-8', 'replace')
     finally:
-        shutil.rmtree(runtime_dir)
         shutil.rmtree(startup_dir)
 

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup_args = dict(
         'console_scripts': [
             # 'jupyter-kernelspec = jupyter_kernel_mgmt.kernelspecapp:KernelSpecApp.launch_instance',
             # 'jupyter-run = jupyter_kernel_mgmt.runapp:RunApp.launch_instance',
-            # 'jupyter-kernel = jupyter_kernel_mgmt.kernelapp:main',
+            'jupyter-kernel = jupyter_kernel_mgmt.kernelapp:main',
         ],
         'jupyter_kernel_mgmt.kernel_type_providers' : [
             'spec = jupyter_kernel_mgmt.discovery:KernelSpecProvider',


### PR DESCRIPTION
Continuation of #41. I've simplified the app to a plain command-line interface using an asyncio event loop (rather than a tornado wrapper around that). I've added creating a second connection file, as we discussed.